### PR TITLE
added schema types for type safety

### DIFF
--- a/src/utils/supabase/schema.ts
+++ b/src/utils/supabase/schema.ts
@@ -1,0 +1,39 @@
+export interface IUsers {
+  id: string,
+  first_name: string,
+  last_name: string,
+  email: string,
+}
+
+export interface IJournalEntries {
+  id: string,
+  user_id: string,
+  entry_date: string,
+  entry: string,
+}
+
+export interface ISleepEntries {
+  id: string,
+  user_id: string,
+  start: string,
+  end: string,
+  entry_date: string,
+}
+
+export interface IResponses {
+  id: string,
+  user_id: string,
+  attribute_id: string,
+  entry_date: string,
+}
+
+export interface IAttributes {
+  id: string,
+  category_id: string,
+  name: string,
+}
+
+export interface ICategories {
+  id: string,
+  name: string,
+}


### PR DESCRIPTION
these can be used for the return types of server actions so we don't have to chain properties with `?` and can validate the information fetched.