### PR TITLE
Add auth and user table sync trigger

### DIFF
--- a/src/actions/auth.ts
+++ b/src/actions/auth.ts
@@ -29,7 +29,7 @@ export async function signup(formData: FormData) {
   // Validate name fields
   const firstNameError = validateName(formData.get('firstName'), 'First name');
   if (firstNameError) return firstNameError;
-  
+
   const lastNameError = validateName(formData.get('lastName'), 'Last name');
   if (lastNameError) return lastNameError;
 
@@ -81,12 +81,12 @@ export async function deleteAccount(userId: string) {
   redirect('/')
 }
 
-export async function modifyAccount(firstName:string, lastName: string, email: string, userId: string){
+export async function modifyAccount(firstName: string, lastName: string, email: string, userId: string) {
   const supabase = await createClient()
 
   const firstNameError = validateName(firstName, 'First name');
   if (firstNameError) return firstNameError;
-  
+
   const lastNameError = validateName(lastName, 'Last name');
   if (lastNameError) return lastNameError;
 
@@ -97,26 +97,22 @@ export async function modifyAccount(firstName:string, lastName: string, email: s
   }
 
   const { error: updateError } = await supabase.from('users').update(dataIn).eq('id', userId)
-    
-  const { error } = await supabase.auth.admin.updateUserById(userId, {
-    email: email,
-    user_metadata: {
-        display_name: `${firstName} ${lastName}`
+  if(updateError) {
+    if(updateError.code === '23505') {
+      return { error: 'Email already in use' }
+    } else {
+      return { error: "An unexpected error occurred. Please try again later." }
     }
-  });
-
-  if(error || updateError){
-    redirect('/error')
   }
 }
 
-export async function modifyPassword(newPassword: string){
+export async function modifyPassword(newPassword: string) {
   const supabase = await createClient()
 
   const { error } = await supabase.auth.updateUser({ password: newPassword })
 
-  if(error){
-    redirect('/error')
+  if (error) {
+    return { error: error.message }
   }
 }
 

--- a/src/components/modify-account-info.tsx
+++ b/src/components/modify-account-info.tsx
@@ -18,8 +18,12 @@ export default function ModifyAccount(props: { profileData: any, userId: string 
     const handleSubmit = async () => {
       // Check if the ref is not null before using it
       if (firstNameRef.current && lastNameRef.current && emailRef.current) {
-        await modifyAccount(firstNameRef.current.value, lastNameRef.current.value, emailRef.current.value, props.userId)
-        toast.success("Profile updated successfully!")
+        const result = await modifyAccount(firstNameRef.current.value, lastNameRef.current.value, emailRef.current.value, props.userId)
+        if (result?.error) {
+          toast.error(result.error)
+        } else {
+          toast.success("Profile updated successfully!")
+        }
       }
     };
 

--- a/src/components/modify-password.tsx
+++ b/src/components/modify-password.tsx
@@ -12,10 +12,14 @@ export default function ModifyPassword() {
   const newPass = useRef<HTMLInputElement>(null)
   const confirmPass = useRef<HTMLInputElement>(null)
 
-  const handleSubmit = () =>{
+  const handleSubmit = async () =>{
     if(confirmPass.current && newPass.current && confirmPass.current.value == newPass.current.value){
-      modifyPassword(newPass.current.value)
-      toast.success("Password updated successfully!")
+      const result = await modifyPassword(newPass.current.value)
+      if(result?.error){
+        toast.error(result.error)
+      } else {
+        toast.success("Password updated successfully!")
+      }
     }
     else if(confirmPass.current && newPass.current && confirmPass.current.value != newPass.current.value){
       toast.warn("Passwords do not match")

--- a/src/utils/supabase/scripts/handle_new_user.sql
+++ b/src/utils/supabase/scripts/handle_new_user.sql
@@ -1,0 +1,16 @@
+-- This trigger automatically creates a profile entry when a new user signs up via Supabase Auth.
+-- See https://supabase.com/docs/guides/auth/managing-user-data#using-triggers for more details.
+create function public.handle_new_user()
+returns trigger
+set search_path = ''
+as $$
+begin
+  insert into public.users (id, first_name, last_name, email)
+  values (new.id, new.raw_user_meta_data->>'first_name', new.raw_user_meta_data->>'last_name', new.email);
+  return new;
+end;
+$$ language plpgsql security definer;
+
+create trigger on_auth_user_created
+  after insert on auth.users
+  for each row execute procedure public.handle_new_user();

--- a/src/utils/supabase/scripts/sync_auth_user_data.sql
+++ b/src/utils/supabase/scripts/sync_auth_user_data.sql
@@ -1,0 +1,25 @@
+CREATE OR REPLACE FUNCTION sync_auth_user_data()
+RETURNS TRIGGER 
+SECURITY DEFINER
+AS $$
+BEGIN
+  -- Sync user data in the auth table
+  UPDATE auth.users
+  SET 
+    raw_user_meta_data = COALESCE(raw_user_meta_data, '{}'::jsonb) 
+    || jsonb_build_object(
+      'display_name', CONCAT(NEW.first_name, ' ', NEW.last_name)
+    ),
+    email = NEW.email 
+  WHERE id = NEW.id;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Step 2: Create the trigger
+CREATE OR REPLACE TRIGGER trigger_sync_auth_user_data
+AFTER UPDATE OF first_name, last_name, email
+ON public.users
+FOR EACH ROW
+EXECUTE FUNCTION sync_auth_user_data();

--- a/src/utils/supabase/scripts/tables.sql
+++ b/src/utils/supabase/scripts/tables.sql
@@ -1,0 +1,21 @@
+create table users (
+  id uuid references auth.users on delete cascade not null primary key,
+  first_name text,
+  last_name text,
+  email text
+);
+-- Set up Row Level Security (RLS)
+alter table users
+  enable row level security;
+
+create policy "Profiles are viewable by self." on users 
+  for select using (auth.uid() = id);
+
+create policy "Users can insert their own profile." on users 
+  for insert with check (auth.uid() = id);
+
+create policy "Users can update own profile." on users 
+  for update using (auth.uid() = id);
+
+create policy "Users can delete own profile." on users 
+  for delete using (auth.uid() = id);


### PR DESCRIPTION
Added a trigger that will update our auth table when our user table updates so we dont need to update both tables manually.

Extras:
- added better error handling for password and account modification if the email is being used by another user
- added scripts files for our triggers and tables