### PR TITLE
cu/XX/clean-up-data-intake

### DIFF
--- a/src/tests/data-intake.spec.ts
+++ b/src/tests/data-intake.spec.ts
@@ -171,6 +171,11 @@ describe('Data Intake Actions', () => {
   });
 
   describe('updateResponses', () => {
+    const responseId = 'response123';
+    const userId = 'user123';
+    const attributeIds = ['attr1', 'attr2'];
+    const scaleRating = 5;
+
     it('should successfully update responses', async () => {
       const matchMock = jest.fn().mockReturnThis();
       const selectMock = jest.fn()
@@ -183,15 +188,16 @@ describe('Data Intake Actions', () => {
       });
 
       await expect(
-        updateResponses(new Set(['attr1', 'attr2']), 'user123', 5),
+        updateResponses(responseId, new Set(attributeIds), userId, scaleRating),
       ).resolves.toBeUndefined();
       expect(mockSupabaseClient.from).toHaveBeenCalledWith('responses');
       expect(updateMock).toHaveBeenCalledWith({
-        attribute_ids: ['attr1', 'attr2'],
-        scale_rating: 5
+        attribute_ids: attributeIds,
+        scale_rating: scaleRating
       });
       expect(matchMock).toHaveBeenCalledWith({
-        user_id: 'user123',
+        id: responseId,
+        user_id: userId,
         entry_date: expect.any(String)
       });
     });
@@ -209,7 +215,7 @@ describe('Data Intake Actions', () => {
       });
 
       await expect(
-        updateResponses(new Set(['attr1']), 'user123', 5),
+        updateResponses(responseId, new Set(attributeIds), userId, scaleRating),
       ).resolves.toBeUndefined();
     });
   });

--- a/src/tests/data-intake.spec.ts
+++ b/src/tests/data-intake.spec.ts
@@ -1,9 +1,9 @@
 import {
-  deleteResponses,
   insertResponses,
   selectAllFromAttributes,
   selectAllFromCategories,
   selectResponsesByDate,
+  updateResponses,
 } from '@/utils/supabase/dbfunctions';
 import { getSupabaseClient } from '@/utils/supabase/client';
 
@@ -78,7 +78,7 @@ describe('Data Intake Actions', () => {
       expect(matchMock).toHaveBeenCalled();
     });
 
-    it('should throw an error when there is a failure', async () => {
+    it('should return null when there is a failure', async () => {
       const matchMock = jest
         .fn()
         .mockResolvedValue({ data: null, error: { message: 'Error' } });
@@ -88,16 +88,15 @@ describe('Data Intake Actions', () => {
         select: selectMock,
       });
 
-      await expect(selectAllFromAttributes()).rejects.toThrow('Error');
+      await expect(selectAllFromAttributes()).resolves.toBeNull();
     });
   });
 
   describe('selectResponsesByDate', () => {
     it('should return responses for a given user and date', async () => {
-      const mockData = [{ id: 1, response: 'Good day' }];
-      const matchMock = jest
-        .fn()
-        .mockResolvedValue({ data: mockData, error: null });
+      const mockData = { id: 1, response: 'Good day' };
+      const matchMock = jest.fn()
+        .mockResolvedValue({ data: [mockData], error: null });
       const selectMock = jest.fn().mockReturnValue({ match: matchMock });
 
       mockSupabaseClient.from.mockReturnValue({
@@ -110,7 +109,7 @@ describe('Data Intake Actions', () => {
       expect(matchMock).toHaveBeenCalled();
     });
 
-    it('should return empty array when no data is found', async () => {
+    it('should return null when no data is found', async () => {
       const matchMock = jest.fn().mockResolvedValue({ data: [], error: null });
       const selectMock = jest.fn().mockReturnValue({ match: matchMock });
 
@@ -119,7 +118,7 @@ describe('Data Intake Actions', () => {
       });
 
       const result = await selectResponsesByDate('user123', '2024-02-23');
-      expect(result).toEqual([]);
+      expect(result).toBeNull();
     });
 
     it('should throw an error when fetching responses fails', async () => {
@@ -134,7 +133,7 @@ describe('Data Intake Actions', () => {
 
       await expect(
         selectResponsesByDate('user123', '2024-02-23'),
-      ).rejects.toThrow('Fetch error');
+      ).resolves.toBeNull();
     });
   });
 
@@ -156,10 +155,9 @@ describe('Data Intake Actions', () => {
       expect(insertMock).toHaveBeenCalled();
     });
 
-    it('should throw an error when insert fails', async () => {
-      const selectMock = jest
-        .fn()
-        .mockResolvedValue({ data: null, error: { message: 'Insert error' } });
+    it('should return when insert fails', async () => {
+      const selectMock = jest.fn()
+        .mockResolvedValue({ data: null, error: { message: 'Insert error' }});
       const insertMock = jest.fn().mockReturnValue({ select: selectMock });
 
       mockSupabaseClient.from.mockReturnValue({
@@ -168,42 +166,51 @@ describe('Data Intake Actions', () => {
 
       await expect(
         insertResponses(new Set(['attr1']), 'user123', 5),
-      ).rejects.toThrow('Insert error');
+      ).resolves.toBeUndefined();
     });
   });
 
-  describe('deleteResponses', () => {
-    it('should successfully delete responses', async () => {
-      const inMock = jest.fn().mockResolvedValue({ error: null });
-      const matchMock = jest.fn().mockReturnValue({ in: inMock });
-      const deleteMock = jest.fn().mockReturnValue({ match: matchMock });
+  describe('updateResponses', () => {
+    it('should successfully update responses', async () => {
+      const matchMock = jest.fn().mockReturnThis();
+      const selectMock = jest.fn()
+        .mockResolvedValue({data: [{}], error: null});
+      const updateMock = jest.fn()
+        .mockReturnValue({match: matchMock, select: selectMock});
 
       mockSupabaseClient.from.mockReturnValue({
-        delete: deleteMock,
+        update: updateMock,
       });
 
       await expect(
-        deleteResponses(new Set(['attr1', 'attr2']), 'user123'),
+        updateResponses(new Set(['attr1', 'attr2']), 'user123', 5),
       ).resolves.toBeUndefined();
-      expect(deleteMock).toHaveBeenCalled();
-      expect(matchMock).toHaveBeenCalled();
-      expect(inMock).toHaveBeenCalled();
+      expect(mockSupabaseClient.from).toHaveBeenCalledWith('responses');
+      expect(updateMock).toHaveBeenCalledWith({
+        attribute_ids: ['attr1', 'attr2'],
+        scale_rating: 5
+      });
+      expect(matchMock).toHaveBeenCalledWith({
+        user_id: 'user123',
+        entry_date: expect.any(String)
+      });
     });
 
-    it('should throw an error when delete fails', async () => {
-      const inMock = jest
-        .fn()
-        .mockResolvedValue({ error: { message: 'Delete error' } });
-      const matchMock = jest.fn().mockReturnValue({ in: inMock });
-      const deleteMock = jest.fn().mockReturnValue({ match: matchMock });
+    it('should return when update fails', async () => {
+      console.error = jest.fn();
+      const matchMock = jest.fn().mockReturnThis();
+      const selectMock = jest.fn()
+        .mockResolvedValue({data: null, error: { message: 'Update error' }});
+      const updateMock = jest.fn()
+        .mockReturnValue({match: matchMock, select: selectMock});
 
       mockSupabaseClient.from.mockReturnValue({
-        delete: deleteMock,
+        update: updateMock,
       });
 
       await expect(
-        deleteResponses(new Set(['attr1', 'attr2']), 'user123'),
-      ).rejects.toThrow('Delete error');
+        updateResponses(new Set(['attr1']), 'user123', 5),
+      ).resolves.toBeUndefined();
     });
   });
 });

--- a/src/utils/supabase/dbfunctions.ts
+++ b/src/utils/supabase/dbfunctions.ts
@@ -155,7 +155,12 @@ export async function selectAllFromCategories(): Promise<Array<ICategories> | nu
  */
 export async function selectAllFromAttributes(): Promise<Array<IAttributes> | null> {
   const { data, error } = await selectData<IAttributes>('attributes');
-  if (error) throw new Error(error.message);
+
+  if (error) {
+    console.error('Error selecting categories:', error);
+    return null;
+  }
+
   return data as unknown as IAttributes[];
 }
 
@@ -168,14 +173,18 @@ export async function selectAllFromAttributes(): Promise<Array<IAttributes> | nu
 export async function selectResponsesByDate(
   userId: string,
   entryDate: string,
-): Promise<Array<IResponses> | null> {
+): Promise<IResponses | null> {
   const { data, error } = await selectData<IResponses>('responses', {
     user_id: userId,
     entry_date: entryDate,
   });
 
-  if (error) throw new Error(error.message);
-  return data as unknown as IResponses[];
+  if (error) {
+    console.error('Error selecting response by date:', error);
+    return null;
+  }
+
+  return data.length > 0 ? data[0] as unknown as IResponses : null;
 }
 
 /**
@@ -194,28 +203,33 @@ export async function insertResponses(
     attribute_ids: Array.from(attributeIds),
     scale_rating: scaleRating,
   }]);
-  if (error) throw new Error(error.message);
-}
 
+  if (error) {
+    console.error('Error inserting response:', error);
+  }
+}
 /**
- * Deletes responses for a given user and date.
- * @param attributeIds - Set of attribute IDs to delete
- * @param userId - The user's ID
+ * Updates an existing response in the database.
+ * @param attributeIds - A set of attribute IDs representing the user's selected attributes.
+ * @param userId - The unique identifier of the user.
+ * @param scaleRating - The user's scale rating for their day.
  */
-export async function deleteResponses(
+export async function updateResponses(
   attributeIds: Set<string>,
   userId: string,
+  scaleRating: number,
 ): Promise<void> {
-  const supabase = getSupabaseClient();
   const entryDate = new Date().toISOString().split('T')[0];
 
-  const { error } = await supabase
-    .from('responses')
-    .delete()
-    .match({ user_id: userId, entry_date: entryDate })
-    .in('attribute_id', Array.from(attributeIds));
+  const { error } = await updateData(
+    'responses',
+    { user_id: userId, entry_date: entryDate },
+    { attribute_ids: Array.from(attributeIds), scale_rating: scaleRating },
+  );
 
-  if (error) throw new Error(error.message);
+  if (error) {
+    console.error('Error updating response:', error);
+  }
 }
 
 export async function deleteJournalEntry(entryId: string) {

--- a/src/utils/supabase/dbfunctions.ts
+++ b/src/utils/supabase/dbfunctions.ts
@@ -210,11 +210,13 @@ export async function insertResponses(
 }
 /**
  * Updates an existing response in the database.
+ * @param responseId - The unique identifier of the response.
  * @param attributeIds - A set of attribute IDs representing the user's selected attributes.
  * @param userId - The unique identifier of the user.
  * @param scaleRating - The user's scale rating for their day.
  */
 export async function updateResponses(
+  responseId: string,
   attributeIds: Set<string>,
   userId: string,
   scaleRating: number,
@@ -223,7 +225,7 @@ export async function updateResponses(
 
   const { error } = await updateData(
     'responses',
-    { user_id: userId, entry_date: entryDate },
+    { id: responseId, user_id: userId, entry_date: entryDate },
     { attribute_ids: Array.from(attributeIds), scale_rating: scaleRating },
   );
 


### PR DESCRIPTION
Updated data-intake logic to update existing entry since attributes are stored as arrays now:
* removed deleteResponses
* selectResponsesByDate returns one object now, not an array
* added updateResponses
* removed deleteResponses tests
* added updateResponses tests